### PR TITLE
chore(deps): bump fast-uri to 3.1.2 (Dependabot #304, #305)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11440,9 +11440,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Bumps transitive `fast-uri` from `3.1.0` → `3.1.2` (via `ajv@8.18.0`).
- Closes two **high** severity Dependabot alerts:
  - **#305** — host confusion via percent-encoded authority delimiters (`<= 3.1.1`)
  - **#304** — path traversal via percent-encoded dot segments (`<= 3.1.0`)
- Lockfile-only change. Existing semver constraint `^3.0.1` already permits this version, so `package.json` is untouched.

## Test plan
- [ ] CI green
- [ ] Dependabot alerts #304 and #305 auto-close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)